### PR TITLE
高版本的unity上，GetFunctionPointer不会跟GUISKin.current有关系，所以可以直接跳过。

### DIFF
--- a/Assets/Scripts/UnityHook/MethodHook.cs
+++ b/Assets/Scripts/UnityHook/MethodHook.cs
@@ -85,7 +85,7 @@ namespace MonoHook
 
         private CodePatcher _codePatcher;
 
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_3_OR_NEWER
         /// <summary>
         /// call `MethodInfo.MethodHandle.GetFunctionPointer()` 
         /// will visit static class `UnityEditor.IMGUI.Controls.TreeViewGUI.Styles` and invoke its static constructor,
@@ -97,7 +97,7 @@ namespace MonoHook
 
         static MethodHook()
         {
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_3_OR_NEWER
             s_fi_GUISkin_current = typeof(GUISkin).GetField("current", BindingFlags.Static | BindingFlags.NonPublic);
 #endif
         }
@@ -126,7 +126,7 @@ namespace MonoHook
             if (isHooked)
                 return;
 
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_3_OR_NEWER
             if (s_fi_GUISkin_current.GetValue(null) != null)
                 DoInstall();
             else
@@ -358,7 +358,7 @@ namespace MonoHook
             }
         }
 
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_3_OR_NEWER
         private void OnEditorUpdate()
         {
             if (s_fi_GUISkin_current.GetValue(null) != null)


### PR DESCRIPTION
高版本的unity上，GetFunctionPointer不会跟GUISKin.current有关系，所以可以直接跳过。避免编辑器代码编译…完瞬间想hook某些代码出现hook失败的问题（因为之前要等GUISKin.current有值）