### PR TITLE
增加个快捷Hook的类

### DIFF
--- a/Assets/Scripts/QuickHook.cs
+++ b/Assets/Scripts/QuickHook.cs
@@ -2,63 +2,110 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
+using UnityEngine;
 using MonoHook;
 
 public class QuickHook
 {
-    Dictionary<string, List<MethodHook>> hookMethodDic;
+    enum HookID
+    {
+        Ctor,
+        Method,
+        Property,
+    }
+
+    Dictionary<Type, Dictionary<string, List<MethodHook>>> hookDic;
 
     Type type;
     Func<string, string> replaceNameFunc;
     Func<string, string> proxyNameFunc;
+    Func<string, string> setterNameFunc;
+    Func<string, string> getterNameFunc;
+    BindingFlags hookFlags;
+    BindingFlags selfFlags;
 
-    public QuickHook(Type type)
+    public QuickHook(Type type, BindingFlags? hookFlags = null, BindingFlags? selfFlags = null)
     {
         this.type = type;
-        hookMethodDic = new Dictionary<string, List<MethodHook>>();
+        hookDic = new Dictionary<Type, Dictionary<string, List<MethodHook>>>();
         replaceNameFunc = x => x;
         proxyNameFunc = x => x + "Proxy";
+        setterNameFunc = x => "set_" + x;
+        getterNameFunc = x => "get_" + x;
+
+        var defaultFlags = BindingFlags.FlattenHierarchy | BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+        this.hookFlags = hookFlags ?? defaultFlags;
+        this.selfFlags = selfFlags ?? defaultFlags;
     }
 
-    public QuickHook(Type type, Func<string, string> replaceNameFunc, Func<string, string> proxyNameFunc) : this(type)
+    public QuickHook(object inst) : this(inst.GetType())
+    {
+    }
+
+    public QuickHook(Type type, Func<string, string> replaceNameFunc, Func<string, string> proxyNameFunc,
+        Func<string, string> setterNameFunc, Func<string, string> getterNameFunc,
+        BindingFlags? hookFlags = null, BindingFlags? selfFlags = null) : this(type, hookFlags, selfFlags)
     {
         this.replaceNameFunc = replaceNameFunc;
         this.proxyNameFunc = proxyNameFunc;
+        this.setterNameFunc = setterNameFunc;
+        this.getterNameFunc = getterNameFunc;
     }
 
-    public bool HookMethod(Type hookType, string hookMethod, BindingFlags hookFlags = BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, BindingFlags selfFlags = BindingFlags.Static | BindingFlags.NonPublic)
+    public int HookCtor(Type hookType, string replaceName = null, string proxyName = null)
     {
-        if (hookMethodDic.TryGetValue(hookMethod, out var hooks))
-            return false;
-
-        hooks = new List<MethodHook>();
-        hookMethodDic.Add(hookMethod, hooks);
-
-        var originalMethods = hookType.GetMethods(hookFlags).Where(method => method.Name == hookMethod).ToList();
-        var replaceMethods = type.GetMethods(selfFlags).Where(method => method.Name == replaceNameFunc(hookMethod)).ToList();
-        var proxyMethods = type.GetMethods(selfFlags).Where(method => method.Name == proxyNameFunc(hookMethod)).ToList();
-
-        foreach (var originalMethod in originalMethods)
+        var counter = 0;
+        while (Internal_Hook(hookType, HookID.Ctor, string.Empty, replaceName ?? replaceNameFunc("Ctor"), proxyName ?? proxyNameFunc("Ctor"), counter > 0))
         {
-            var replaceMethod = FindMethodsBySignature(replaceMethods, originalMethod);
-            var proxyMethod = FindMethodsBySignature(proxyMethods, originalMethod);
-            if (replaceMethod != null && proxyMethod != null)
+            counter++;
+        }
+
+        return counter;
+    }
+
+    public int HookMethod(Type hookType, string hookMethod, string replaceName = null, string proxyName = null)
+    {
+        var counter = 0;
+        while (Internal_Hook(hookType, HookID.Method, hookMethod, replaceName ?? replaceNameFunc(hookMethod),
+            proxyName ?? proxyNameFunc(hookMethod), counter > 0))
+        {
+            counter++;
+        }
+
+        return counter;
+    }
+
+    public int HookProperty(Type hookType, string hookProperty, string replaceName = null, string proxyName = null)
+    {
+        var counter = 0;
+        while (Internal_Hook(hookType, HookID.Property, hookProperty, replaceName ?? replaceNameFunc(hookProperty),
+            proxyName ?? proxyNameFunc(hookProperty), counter > 0))
+        {
+            counter++;
+        }
+
+        return counter;
+    }
+
+    public void UnHookCtor(Type hookType)
+    {
+        UnHookMethod(hookType, string.Empty);
+    }
+
+    public void UnHookMethod(Type hookType, string hookMethod)
+    {
+        if (hookDic.TryGetValue(hookType, out var typeToHooks) && typeToHooks.Remove(hookMethod, out var hooks))
+        {
+            foreach (var item in hooks)
             {
-                hooks.Add(new MethodHook(originalMethod, replaceMethod, proxyMethod));
+                item.Uninstall();
             }
         }
-
-        foreach (var item in hooks)
-        {
-            item.Install();
-        }
-
-        return hooks.Count > 0;
     }
 
-    public void UnHookMethod(string methodName)
+    public void UnHookProperty(Type hookType, string hookProperty)
     {
-        if (hookMethodDic.Remove(methodName, out var hooks))
+        if (hookDic.TryGetValue(hookType, out var typeToHooks) && typeToHooks.Remove(hookProperty, out var hooks))
         {
             foreach (var item in hooks)
             {
@@ -69,31 +116,234 @@ public class QuickHook
 
     public void UnHookAll()
     {
-        foreach (var hooks in hookMethodDic.Values)
+        foreach (var typeToHooks in hookDic.Values)
         {
-            foreach (var item in hooks)
+            foreach (var hooks in typeToHooks.Values)
             {
-                item.Uninstall();
+                foreach (var item in hooks)
+                    item.Uninstall();
             }
         }
 
-        hookMethodDic.Clear();
+        hookDic.Clear();
     }
 
-    MethodInfo FindMethodsBySignature(List<MethodInfo> methods, MethodInfo compareMethod)
+    bool Internal_Hook(Type hookType, HookID hookID, string hookMember, string replaceName, string proxyName, bool ignoreError = false)
     {
-        var compareParams = compareMethod.GetParameters();
+        if (!hookDic.TryGetValue(hookType, out var typeToHooks))
+        {
+            typeToHooks = new Dictionary<string, List<MethodHook>>();
+            hookDic.Add(hookType, typeToHooks);
+        }
+
+        if (!typeToHooks.TryGetValue(hookMember, out var hooks))
+        {
+            hooks = new List<MethodHook>();
+            typeToHooks.Add(hookMember, hooks);
+        }
+
+        var originalMethods = default(List<MethodBase>);
+        switch (hookID)
+        {
+            case HookID.Ctor:
+                originalMethods = hookType.GetConstructors(hookFlags).ToList().ConvertAll(x => (MethodBase)x);
+                break;
+            case HookID.Method:
+                originalMethods = hookType.GetMethods(hookFlags).Where(x => x.Name == hookMember && !x.IsGenericMethod).ToList().ConvertAll(x => (MethodBase)x);
+                break;
+            case HookID.Property:
+                var properties = hookType.GetProperties(hookFlags).Where(x => x.Name == hookMember).ToList();
+                originalMethods = new List<MethodBase>(properties.Count * 2);
+                foreach (var property in properties)
+                {
+                    if (property.SetMethod != null)
+                        originalMethods.Add(property.SetMethod);
+                    if (property.GetMethod != null)
+                        originalMethods.Add(property.GetMethod);
+                }
+                break;
+        }
+
+        foreach (var hook in hooks)
+            originalMethods.Remove(hook.targetMethod);
+
+        if (originalMethods.Count == 0)
+        {
+            if (!ignoreError)
+            {
+                switch (hookID)
+                {
+                    case HookID.Ctor:
+                        Debug.LogError($"Failed to hook {hookID}. No constructor found in type {hookType}.");
+                        break;
+                    case HookID.Method:
+                        Debug.LogError($"Failed to hook {hookID}. No method {hookMember} found in type {hookType}.");
+                        break;
+                    case HookID.Property:
+                        Debug.LogError($"Failed to hook {hookID}. No property {hookMember} found in type {hookType}.");
+                        break;
+                    default:
+                        Debug.LogError($"Failed to hook {hookID}.");
+                        break;
+                }
+            }
+
+            return false;
+        }
+
+        var methodHook = default(MethodHook);
+        var replaceMethods = default(List<MethodInfo>);
+        var proxyMethods = default(List<MethodInfo>);
+
+        switch (hookID)
+        {
+            case HookID.Ctor:
+            case HookID.Method:
+                {
+                    replaceMethods = type.GetMethods(selfFlags).Where(x => x.Name == replaceName).ToList();
+                    proxyMethods = type.GetMethods(selfFlags).Where(x => x.Name == proxyName).ToList();
+                }
+                break;
+            case HookID.Property:
+                {
+                    // 查找属性
+                    var replaceProperties = type.GetProperties(selfFlags).Where(x => x.Name == replaceName).ToList();
+                    var proxyProperties = type.GetProperties(selfFlags).Where(x => x.Name == proxyName).ToList();
+
+                    replaceMethods = new List<MethodInfo>(replaceProperties.Count * 2);
+                    proxyMethods = new List<MethodInfo>(proxyProperties.Count * 2);
+
+                    foreach (var item in replaceProperties)
+                    {
+                        if (item.SetMethod != null)
+                            replaceMethods.Add(item.SetMethod);
+                        if (item.GetMethod != null)
+                            replaceMethods.Add(item.GetMethod);
+                    }
+
+                    foreach (var item in proxyProperties)
+                    {
+                        if (item.SetMethod != null)
+                            proxyMethods.Add(item.SetMethod);
+                        if (item.GetMethod != null)
+                            proxyMethods.Add(item.GetMethod);
+                    }
+
+                    // 查找方法
+                    if (replaceMethods.Count != proxyMethods.Count || replaceMethods.Count == 0)
+                    {
+                        var setReplaceMethods = type.GetMethods(selfFlags).Where(x => x.Name == setterNameFunc(replaceName)).ToList();
+                        var getReplaceMethods = type.GetMethods(selfFlags).Where(x => x.Name == getterNameFunc(replaceName)).ToList();
+
+                        var setProxyMethods = type.GetMethods(selfFlags).Where(x => x.Name == setterNameFunc(proxyName)).ToList();
+                        var getProxyMethods = type.GetMethods(selfFlags).Where(x => x.Name == getterNameFunc(proxyName)).ToList();
+
+                        replaceMethods = new List<MethodInfo>(setReplaceMethods.Count * 2);
+                        proxyMethods = new List<MethodInfo>(setProxyMethods.Count * 2);
+
+                        replaceMethods.AddRange(setReplaceMethods);
+                        replaceMethods.AddRange(getReplaceMethods);
+
+                        proxyMethods.AddRange(setProxyMethods);
+                        proxyMethods.AddRange(getProxyMethods);
+                    }
+                }
+                break;
+        }
+
+        foreach (var originalMethod in originalMethods)
+        {
+            var replaceMethod = FindMethodBySignature(hookID, replaceMethods, originalMethod);
+            var proxyMethod = FindMethodBySignature(hookID, proxyMethods, originalMethod);
+            if (replaceMethod != null && proxyMethod != null)
+            {
+                methodHook = new MethodHook(originalMethod, replaceMethod, proxyMethod);
+                switch (hookID)
+                {
+                    case HookID.Ctor:
+                        Debug.Log($"Successfully hooked {hookID}. {hookType} ({originalMethod}) -> {type} ({replaceMethod}),");
+                        break;
+                    case HookID.Method:
+                        Debug.Log($"Successfully hooked {hookID}. {hookType} ({originalMethod}) -> {type} ({replaceMethod}),");
+                        break;
+                    case HookID.Property:
+                        Debug.Log($"Successfully hooked {hookID} . {hookType} ({originalMethod}) -> {type} ({replaceMethod}),");
+                        break;
+                    default:
+                        Debug.Log($"Successfully hooked {hookID}.");
+                        break;
+                }
+                break;
+            }
+        }
+
+        if (methodHook == null)
+        {
+            if (!ignoreError)
+            {
+                Debug.LogError($"Failed to hook {hookID}. No method {replaceName} or {proxyName} found in type {type}, or their signatures do not match.");
+            }
+
+            return false;
+        }
+        else
+        {
+            methodHook.Install();
+            hooks.Add(methodHook);
+            return true;
+        }
+    }
+
+    MethodInfo FindMethodBySignature(HookID hookID, List<MethodInfo> methods, MethodBase originalMethod)
+    {
+        if (methods?.Count == 0)
+            return null;
+
+        Type compareReturnType = null;
+        switch (hookID)
+        {
+            case HookID.Ctor:
+                compareReturnType = typeof(void);
+                break;
+            case HookID.Method:
+            case HookID.Property:
+                compareReturnType = ((MethodInfo)originalMethod).ReturnType;
+                break;
+        }
+
+        // 查找实例方法
+        var compareParamTypes = originalMethod.GetParameters().ToList().ConvertAll(x => x.ParameterType);
+        var method = FindMethodBySignature(methods, compareParamTypes, compareReturnType, true);
+        if (method != null)
+            return method;
+
+        // 查找静态方法
+        if (!originalMethod.IsStatic)
+            compareParamTypes.Insert(0, originalMethod.DeclaringType);
+
+        method = FindMethodBySignature(methods, compareParamTypes, compareReturnType, false);
+        if (method != null)
+            return method;
+
+        return null;
+    }
+
+    MethodInfo FindMethodBySignature(List<MethodInfo> methods, List<Type> compareParamTypes, Type compareReturnType, bool searchInstance)
+    {
         foreach (var method in methods)
         {
-            if (compareMethod.ReturnType == method.ReturnType)
+            if (searchInstance && method.IsStatic)
+                continue;
+
+            if (TypeIsEqual(method.ReturnType, compareReturnType))
             {
                 var @params = method.GetParameters();
-                if (@params.Length == compareParams.Length)
+                if (@params.Length == compareParamTypes?.Count)
                 {
                     var isMatch = true;
                     for (int i = 0; i < @params.Length; i++)
                     {
-                        if (@params[i].ParameterType != compareParams[i].ParameterType)
+                        if (!TypeIsEqual(@params[i].ParameterType, compareParamTypes[i]))
                         {
                             isMatch = false;
                             break;
@@ -108,5 +358,16 @@ public class QuickHook
         }
 
         return null;
+    }
+
+    bool TypeIsEqual(Type x, Type y)
+    {
+        if (x == y)
+            return true;
+
+        if (x.IsAssignableFrom(y))
+            return true;
+
+        return false;
     }
 }

--- a/Assets/Scripts/QuickHook.cs
+++ b/Assets/Scripts/QuickHook.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Linq;
+using MonoHook;
+
+public class QuickHook
+{
+    Dictionary<string, List<MethodHook>> hookMethodDic;
+
+    Type type;
+    Func<string, string> replaceNameFunc;
+    Func<string, string> proxyNameFunc;
+
+    public QuickHook(Type type)
+    {
+        this.type = type;
+        hookMethodDic = new Dictionary<string, List<MethodHook>>();
+        replaceNameFunc = x => x;
+        proxyNameFunc = x => x + "Proxy";
+    }
+
+    public QuickHook(Type type, Func<string, string> replaceNameFunc, Func<string, string> proxyNameFunc) : this(type)
+    {
+        this.replaceNameFunc = replaceNameFunc;
+        this.proxyNameFunc = proxyNameFunc;
+    }
+
+    public bool HookMethod(Type hookType, string hookMethod, BindingFlags hookFlags = BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, BindingFlags selfFlags = BindingFlags.Static | BindingFlags.NonPublic)
+    {
+        if (hookMethodDic.TryGetValue(hookMethod, out var hooks))
+            return false;
+
+        hooks = new List<MethodHook>();
+        hookMethodDic.Add(hookMethod, hooks);
+
+        var originalMethods = hookType.GetMethods(hookFlags).Where(method => method.Name == hookMethod).ToList();
+        var replaceMethods = type.GetMethods(selfFlags).Where(method => method.Name == replaceNameFunc(hookMethod)).ToList();
+        var proxyMethods = type.GetMethods(selfFlags).Where(method => method.Name == proxyNameFunc(hookMethod)).ToList();
+
+        foreach (var originalMethod in originalMethods)
+        {
+            var replaceMethod = FindMethodsBySignature(replaceMethods, originalMethod);
+            var proxyMethod = FindMethodsBySignature(proxyMethods, originalMethod);
+            if (replaceMethod != null && proxyMethod != null)
+            {
+                hooks.Add(new MethodHook(originalMethod, replaceMethod, proxyMethod));
+            }
+        }
+
+        foreach (var item in hooks)
+        {
+            item.Install();
+        }
+
+        return hooks.Count > 0;
+    }
+
+    public void UnHookMethod(string methodName)
+    {
+        if (hookMethodDic.Remove(methodName, out var hooks))
+        {
+            foreach (var item in hooks)
+            {
+                item.Uninstall();
+            }
+        }
+    }
+
+    public void UnHookAll()
+    {
+        foreach (var hooks in hookMethodDic.Values)
+        {
+            foreach (var item in hooks)
+            {
+                item.Uninstall();
+            }
+        }
+
+        hookMethodDic.Clear();
+    }
+
+    MethodInfo FindMethodsBySignature(List<MethodInfo> methods, MethodInfo compareMethod)
+    {
+        var compareParams = compareMethod.GetParameters();
+        foreach (var method in methods)
+        {
+            if (compareMethod.ReturnType == method.ReturnType)
+            {
+                var @params = method.GetParameters();
+                if (@params.Length == compareParams.Length)
+                {
+                    var isMatch = true;
+                    for (int i = 0; i < @params.Length; i++)
+                    {
+                        if (@params[i].ParameterType != compareParams[i].ParameterType)
+                        {
+                            isMatch = false;
+                            break;
+                        }
+                    }
+                    if (isMatch)
+                    {
+                        return method;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/Assets/Scripts/QuickHook.cs.meta
+++ b/Assets/Scripts/QuickHook.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb5a8597a76dd5547b5bf3f8292902f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
目前使用上来，hook一些多重载的方法的时候会有些麻烦，所以才有意搞了这个类

举个例子，下面只需要传入 hook的类型和方法名，则可自动搜索需要hook的目标类型与当前类型中的方法，两者方法签名一致的就会自动hook住
```
[InitializeOnLoad]
public class LogFilter
{
    static QuickHook hook;

    static LogFilter()
    {
        hook = new QuickHook(typeof(LogFilter));
        hook.HookMethod(Debug.unityLogger.GetType(), "Log");
        hook.HookMethod(Debug.unityLogger.GetType(), "LogFormat");
    }

    [MethodImpl(MethodImplOptions.NoOptimization)]
    static void Log(ILogger logger, LogType logType, string tag, object message, Object context)
    {
        if (logType == LogType.Log)
        {
            var msg = message?.ToString();
            if (context == null && string.IsNullOrEmpty(tag) && !string.IsNullOrEmpty(msg))
            {
                // 测试数据
                if (msg.Contains("test"))
                    LogProxy(logger, logType, tag, message, context);
            }
        }
        else
        {
            LogProxy(logger, logType, tag, message, context);
        }
    }
    [MethodImpl(MethodImplOptions.NoOptimization)]
    static void LogProxy(ILogger logger, LogType logType, string tag, object message, Object context) { }


    [MethodImpl(MethodImplOptions.NoOptimization)]
    static void Log(ILogger logger, LogType logType, object message)
    {
        Log(logger, logType, null, message, null);
    }
    [MethodImpl(MethodImplOptions.NoOptimization)]
    static void LogProxy(ILogger logger, LogType logType, object message) { }


    [MethodImpl(MethodImplOptions.NoOptimization)]
    static void Log(ILogger logger, LogType logType, object message, Object context)
    {
        Log(logger, logType, null, message, context);
    }
    [MethodImpl(MethodImplOptions.NoOptimization)]
    static void LogProxy(ILogger logger, LogType logType, object message, Object context) { }


    [MethodImpl(MethodImplOptions.NoOptimization)]
    static void Log(ILogger logger, string tag, object message)
    {
        Log(logger, LogType.Log, tag, message, null);
    }
    [MethodImpl(MethodImplOptions.NoOptimization)]
    static void LogProxy(ILogger logger, string tag, object message) { }


    [MethodImpl(MethodImplOptions.NoOptimization)]
    static void LogFormat(ILogger logger, LogType logType, string format, params object[] args)
    {
        Log(logger, logType, null, string.Format(format, args), null);
    }
    [MethodImpl(MethodImplOptions.NoOptimization)]
    static void LogFormatProxy(ILogger logger, LogType logType, string format, params object[] args) { }
}
````
